### PR TITLE
Removes 3 errors

### DIFF
--- a/programming-learning-tool/src/SolutionPage.vue
+++ b/programming-learning-tool/src/SolutionPage.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import { ref } from 'vue';  // Import ref to create a reactive variable
-import Navbar from './components/Navbar.vue';
-import GroupCollapsible from './components/GroupCollapsible.vue';
+import * as Navbar from './components/Navbar.vue';
+import * as GroupCollapsible from './components/GroupCollapsible.vue';
+import { discriminatedUnion } from 'zod';
 
 const serverHost:string = "http://localhost:5001";
 
@@ -29,6 +30,7 @@ const submitCode = async (): Promise<void> => {
 </script>
 
 <template>
+  <div>
   <Navbar />
   <div class="min-h-screen flex flex-col">
     <!-- Top containers (left and right) with more vertical height -->
@@ -97,4 +99,5 @@ const submitCode = async (): Promise<void> => {
       </div>
     </div>
   </div>
+</div>
 </template>

--- a/programming-learning-tool/src/TestPage.vue
+++ b/programming-learning-tool/src/TestPage.vue
@@ -1,1 +1,4 @@
 <!-- purly used for testing UI. Not actually used for anything related to 'tests'-->
+
+<template>
+</template>


### PR DESCRIPTION
Removes "Module has no default export error" and "Component template should contain exactly one root element" IDE errors on my machine.

it also fixes a build issue where TestPage.vue doesn't have a template tag (which is required)

Perhaps I should have made a few issues regarding this, but I didnt't feel like it, because I just encountered the issues.

## PR purpose description


## Quality check-list
-[X] I have performed a self-review
   - Yes it removes the errors I had when I opened main
   
-[ ] Unit tests have been created for the code 
   - No, it does not seem relevant
   
-[X] I have used linting/static code check 
   - The kind the IDE has built-in.
